### PR TITLE
licensezero.json: Set version to "1.0.0"

### DIFF
--- a/licensezero.json
+++ b/licensezero.json
@@ -1,5 +1,5 @@
 {
-  "version": "",
+  "version": "1.0.0",
   "licensezero": [
     {
       "agentSignature": "44f275b1d6d394c8474d6bf8ef13f0668e5a753d4bb1e6c3bb3523652e791dec496d52ef832a4d07c296a43feae4c66e422c06f1818021532a6d836199491809",


### PR DESCRIPTION
@joehand, this PR comes from my quick review of neat-log.  I saw that the `version` property in `licensezero.json` was unset. This was a (mostly harmless) bug in the CLI, which I've just fixed.