### PR TITLE
Call clear on resize event instead of render

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function neatLog (views, opts) {
   bus.render = render
   bus.clear = clear
 
-  diffy.on('resize', render)
+  diffy.on('resize', clear)
   input.on('ctrl-c', function () {
     render()
     if (bus.listeners('exit').length === 0) return process.exit()


### PR DESCRIPTION
Sometimes when resizing there are some weird artifacts. Example below from `cabal`:

![screenshot from 2018-08-05 04-20-34](https://user-images.githubusercontent.com/308049/43682061-0822174c-9868-11e8-911d-4e03dd0f08ca.png)

I must admit I don't know _exactly_ what's going on. It might be a bug in `diffy`, but I don't really know how to troubleshoot this perfectly.

If we do `clear` instead of `render` on `'resize'` event it fixes the problems and I think it's a pretty decent thing to do, to start with a fresh diffy after the window as changed size. It doesn't happen often and more important that we end up in a good state.
