### PR TITLE
Clarify that neat-input is integrated and link to Cabal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A neat logger for command line tools, inspired by [Choo](https://github.com/yosh
 * Use easy-to-read strings to create console outputs.
 * Automatically diff template output with existing console (via [diffy](https://github.com/mafintosh/diffy)) (pretty much React for your terminal).
 * Update console output in any order with event based output.
-* Handle command line input via [neat-input](https://github.com/mafintosh/neat-input).
+* Handle command line input via integrated [neat-input](https://github.com/mafintosh/neat-input) on the `input` property ([example](https://github.com/cabal-club/cabal/blob/master/neat-screen.js#L28)).
 * Pretty neat!
 
 ### Example


### PR DESCRIPTION
I was initially confused and thought that neat-log worked well with neat-input, not that it was integrated into the module (as the input property is not documented in the readme). This minor clarification makes this clear and links to the Cabal source showing how to initialise neat-log with neat-input support.